### PR TITLE
Dockerfile compatability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 # Stage 1: Building
-FROM alpine:3.10.2 AS build
+FROM alpine:3.10.3 AS build
 # Build tools
 RUN apk add --no-cache git g++ make cmake
 # Build SEAL & spsl
 RUN mkdir /building && cd /building && \
     git clone --single-branch --branch 3.3.1 https://github.com/microsoft/SEAL.git && cd SEAL/native/src && \
-    cmake . && make -j8 && cd /building && \
-    git clone https://github.com/secure-pprl/secure-p-signature-linkage.git && \
-    cd secure-p-signature-linkage/ && \
+    cmake . && make -j8
+ADD . ./building/secure-p-signature-linkage/
+RUN cd /building/secure-p-signature-linkage && \
     CPPFLAGS='-isystem /building/SEAL/native/src' LIBSEAL_PATH=/building/SEAL/native/lib/libseal.a make -j8
 
 # Stage 2: Deployment
-FROM alpine:3.10.2 AS deploy
+FROM alpine:3.10.3 AS deploy
 # Library packages required for running
 RUN apk add --no-cache python3 py3-cffi py3-numpy libstdc++ libgomp
 # Brings over essential SEAL source and SPPRL systems

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.10.2 AS build
 RUN apk add --no-cache git g++ make cmake
 # Build SEAL & spsl
 RUN mkdir /building && cd /building && \
-    git clone https://github.com/microsoft/SEAL.git && cd SEAL/native/src && \
+    git clone --single-branch --branch 3.3.1 https://github.com/microsoft/SEAL.git && cd SEAL/native/src && \
     cmake . && make -j8 && cd /building && \
     git clone https://github.com/secure-pprl/secure-p-signature-linkage.git && \
     cd secure-p-signature-linkage/ && \


### PR DESCRIPTION
When cloning Microsoft SEAL in the docker image creation, the current default is set to clone from the master branch. However, there exists compatibility issues with versions above 3.3.1.

As such, setting the SEAL clone to be at version 3.3.1 as a temporary fix.