### PR TITLE
Docker should build with local files rather than pulling from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ FROM alpine:3.10.2 AS build
 # Build tools
 RUN apk add --no-cache git g++ make cmake
 # Build SEAL & spsl
-RUN mkdir /building && cd /building && \
-    git clone https://github.com/microsoft/SEAL.git && cd SEAL/native/src && \
-    cmake . && make -j8 && cd /building && \
-    git clone https://github.com/secure-pprl/secure-p-signature-linkage.git && \
-    cd secure-p-signature-linkage/ && \
+RUN mkdir /building && mkdir /building/secure-p-signature-linkage
+WORKDIR /building
+RUN git clone --single-branch --branch 3.3.1 https://github.com/microsoft/SEAL.git && cd SEAL/native/src && \
+    cmake . && make -j8
+ADD . /building/secure-p-signature-linkage/
+RUN cd /building/secure-p-signature-linkage && \
     CPPFLAGS='-isystem /building/SEAL/native/src' LIBSEAL_PATH=/building/SEAL/native/lib/libseal.a make -j8
 
 # Stage 2: Deployment


### PR DESCRIPTION
Also reorders so that recompiling SEAL is not required after making local changes.

